### PR TITLE
add support for requiring arbitrary strings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+components

--- a/index.js
+++ b/index.js
@@ -11,12 +11,6 @@ var strtojs = require('string-to-js');
 module.exports = plugin;
 
 /**
- * Regexp
- */
-
-var rtype = /^(html|json|css)$/;
-
-/**
  * Initialize `plugin`
  *
  * @param {Object} file
@@ -26,7 +20,6 @@ var rtype = /^(html|json|css)$/;
 function plugin() {
   return function stoj(file, duo) {
     if ('js' != duo.type) return;
-    if (!rtype.test(file.type)) return;
     file.src = 'json' == file.type
       ? 'module.exports = ' + file.src + ';'
       : strtojs(file.src);

--- a/test/fixtures/shader/index.fs
+++ b/test/fixtures/shader/index.fs
@@ -1,0 +1,1 @@
+void main(void) {}

--- a/test/string-to-js.js
+++ b/test/string-to-js.js
@@ -13,7 +13,6 @@ var vm = require('vm');
  */
 
 describe('duo-string-to-js', function() {
-
   it('should support html', function *() {
     var duo = build('html');
     duo.use(str2js());
@@ -28,6 +27,14 @@ describe('duo-string-to-js', function() {
     var js = yield duo.run();
     var ctx = evaluate(js).main;
     assert.deepEqual(ctx, { key: 'value' });
+  });
+
+  it('should support anything', function *() {
+    var duo = build('shader');
+    duo.use(str2js());
+    var js = yield duo.run();
+    var ctx = evaluate(js).main;
+    assert('void main(void) {}\n' == ctx);
   });
 })
 


### PR DESCRIPTION
wasn't able to get the test passing right now, it looks like duo (which gets installed as a devDependency in this repo) pins a specific version of duo-string-to-js, so it never uses the one that's being tested. It looks like duo isn't running any plugins atm.

but, this seems like it should work. thoughts?
